### PR TITLE
fix: make behavior identical to git-user-name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,17 @@
 /*!
  * git-user-email <https://github.com/jonschlinkert/git-user-email>
  *
- * Copyright (c) 2014-2015, Jon Schlinkert.
- * Licensed under the MIT License.
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
  */
 
-'use strict';
-
-var fs = require('fs');
-var path = require('path');
 var gitconfig = require('git-config-path');
 var parse = require('parse-git-config');
 var extend = require('extend-shallow');
 
-module.exports = function gitUserEmail(opts) {
-  opts = extend({cwd: '/', path: gitconfig()}, opts);
-  var config = parse.sync(opts);
-  if (typeof config === 'object' && config.hasOwnProperty('user')) {
-    return config.user.email;
-  }
-  return null;
+module.exports = function(options) {
+  var gc = gitconfig(extend({type: 'global'}, options && options.gitconfig));
+  options = extend({cwd: '/', path: gc}, options);
+  var config = parse.sync(options) || {};
+  return config.user ? config.user.email : null;
 };


### PR DESCRIPTION
Fixes #1 and fixes #3

Did I copy and paste the code from `git-user-name` and replace the word `name` with `email`? Yes. Yes I did.